### PR TITLE
サムチェックの処理が正しく記述されていなかったので、正しい処理に書き換えた。

### DIFF
--- a/rs405cb.cpp
+++ b/rs405cb.cpp
@@ -245,12 +245,12 @@ short RSGetAngle( HANDLE hComm )
 		return -2;
 	}
 
-	// 受信データの確認
-	sum = readbuf[2];
+	// 受信データの確認(サムチェック)
 	for( i = 3; i < 26; i++ ){
 		sum = sum ^ readbuf[i];
 	}
-	if( sum ){
+	//チェックサムはバッファの27バイト目に入ってる
+	if( sum != readbuf[26] ){
 		printf("sumError\n");
 		// チェックサムエラー
 		return -3;


### PR DESCRIPTION
既存の角度取得時のチェックサム周りの処理は、サムの計算が間違っている上に、チェックサムが0以外の場合はすべてエラー扱いしているために、角度の取得が正常に行えない状態になっていましたので、修正しました。
